### PR TITLE
Issue 11: Adjust page width for wide examples

### DIFF
--- a/css/poole.css
+++ b/css/poole.css
@@ -183,6 +183,8 @@ pre code {
 .highlight {
   margin-bottom: 1rem;
   border-radius: 4px;
+  white-space: pre;
+  overflow-x: auto;
 }
 .highlight pre {
   margin-bottom: 0;


### PR DESCRIPTION
As discussed in #11. Added two lines for <code>.highlight</code> in <code>poole.css</code> that puts a horizontal slidebar to preformatted text and prevent (unwanted) line breaks, if it is neccessary.