### PR TITLE
Code output and command lines as code block

### DIFF
--- a/wiki/BioSQL.md
+++ b/wiki/BioSQL.md
@@ -49,12 +49,16 @@ example we'll talk about the most common choice, MySQL. How you do this
 will also depend on your operating system, for example on a Debian or
 Ubuntu Linux machine try this:
 
-`sudo apt-get install mysql-common mysql-server python-mysqldb`
+``` bash
+sudo apt-get install mysql-common mysql-server python-mysqldb
+```
 
 It will also be important to have perl (to run some of the setup
 scripts). Again, on a Debian or Ubuntu Linux machine try this:
 
-`sudo apt-get install perl`
+``` bash
+sudo apt-get install perl
+```
 
 You may find perl is already installed.
 
@@ -83,57 +87,67 @@ Creating the empty database
 The following command line should create a new database on your own
 computer called *bioseqdb*, belonging to the *root* user account:
 
-`mysqladmin -u root create bioseqdb`
+``` bash
+mysqladmin -u root create bioseqdb
+```
 
 We can then tell MySQL to load the BioSQL scheme we downloaded above.
 Change to the scripts subdirectory from the unzipped BioSQL download,
 then:
 
-`mysql -u root bioseqdb < biosqldb-mysql.sql`
+``` bash
+mysql -u root bioseqdb < biosqldb-mysql.sql
+```
 
 You can have a quick play using the mysql command line tool, for
 example:
 
-`mysql --user=root bioseqdb -e "show tables"`
+``` bash
+mysql --user=root bioseqdb -e "show tables"
+```
 
 giving:
 
-`+----------------------------+`  
-`| Tables_in_bioseqdb         |`  
-`+----------------------------+`  
-`| biodatabase                |`  
-`| bioentry                   |`  
-`| bioentry_dbxref            |`  
-`| bioentry_path              |`  
-`| bioentry_qualifier_value   |`  
-`| bioentry_reference         |`  
-`| bioentry_relationship      |`  
-`| biosequence                |`  
-`| comment                    |`  
-`| dbxref                     |`  
-`| dbxref_qualifier_value     |`  
-`| location                   |`  
-`| location_qualifier_value   |`  
-`| ontology                   |`  
-`| reference                  |`  
-`| seqfeature                 |`  
-`| seqfeature_dbxref          |`  
-`| seqfeature_path            |`  
-`| seqfeature_qualifier_value |`  
-`| seqfeature_relationship    |`  
-`| taxon                      |`  
-`| taxon_name                 |`  
-`| term                       |`  
-`| term_dbxref                |`  
-`| term_path                  |`  
-`| term_relationship          |`  
-`| term_relationship_term     |`  
-`| term_synonym               |`  
-`+----------------------------+`
+```
++----------------------------+  
+| Tables_in_bioseqdb         |  
++----------------------------+  
+| biodatabase                |  
+| bioentry                   |  
+| bioentry_dbxref            |  
+| bioentry_path              |  
+| bioentry_qualifier_value   |  
+| bioentry_reference         |  
+| bioentry_relationship      |  
+| biosequence                |  
+| comment                    |  
+| dbxref                     |  
+| dbxref_qualifier_value     |  
+| location                   |  
+| location_qualifier_value   |  
+| ontology                   |  
+| reference                  |  
+| seqfeature                 |  
+| seqfeature_dbxref          |  
+| seqfeature_path            |  
+| seqfeature_qualifier_value |  
+| seqfeature_relationship    |  
+| taxon                      |  
+| taxon_name                 |  
+| term                       |  
+| term_dbxref                |  
+| term_path                  |  
+| term_relationship          |  
+| term_relationship_term     |  
+| term_synonym               |  
++----------------------------+
+```
 
 Or, to look inside a table:
 
-`mysql --user=root bioseqdb -e "select * from bioentry;"`
+``` bash
+mysql --user=root bioseqdb -e "select * from bioentry;"
+```
 
 This should return no rows as the table is empty.
 
@@ -147,14 +161,18 @@ biosqldb-pg.sql BioSQL version 1.0.1
 First you need to set up user permissions, if you are not sure how to do
 this, try:
 
-` su - postgres`  
-` createuser `<your user name>
+``` bash
+su - postgres  
+createuser <your user name>
+```
 
 Then, assuming you are logged-in as <your user name> and Postgres is
 running on the local machine, you should be able to do the following:
 
-`createdb biosqldb`  
-`psql biosqldb < biosqldb-pg.sql`
+``` bash
+createdb biosqldb  
+psql biosqldb < biosqldb-pg.sql
+```
 
 Run *psql* and type enter *\\d <ENTER>* to see all the entities created.
 
@@ -176,7 +194,9 @@ information needed downloaded as needed from Entrez.
 To update the NCBI taxonomy, change to the scripts subdirectory from the
 unzipped BioSQL download, then:
 
-`./load_ncbi_taxonomy.pl --dbname bioseqdb --driver mysql --dbuser root --download true`
+``` bash
+./load_ncbi_taxonomy.pl --dbname bioseqdb --driver mysql --dbuser root --download true
+```
 
 For PostgreSQL you need to have the perl DBD-Pg module installed - Using
 CPAN: "perl -MCPAN -e 'install DBI'; perl -MCPAN -e 'install DBD::Pg'".
@@ -191,17 +211,19 @@ You should see this output at the command prompt - be warned that some
 of these steps do take a while (especially *rebuilding nested set
 left/right values*):
 
-`Loading NCBI taxon database in taxdata:`  
-`        ... retrieving all taxon nodes in the database`  
-`        ... reading in taxon nodes from nodes.dmp`  
-`        ... insert / update / delete taxon nodes`  
-`        ... (committing nodes)`  
-`        ... rebuilding nested set left/right values`  
-`        ... reading in taxon names from names.dmp`  
-`        ... deleting old taxon names`  
-`        ... inserting new taxon names`  
-`        ... cleaning up`  
-`Done.`
+```
+Loading NCBI taxon database in taxdata:  
+        ... retrieving all taxon nodes in the database  
+        ... reading in taxon nodes from nodes.dmp  
+        ... insert / update / delete taxon nodes  
+        ... (committing nodes)  
+        ... rebuilding nested set left/right values  
+        ... reading in taxon names from names.dmp  
+        ... deleting old taxon names  
+        ... inserting new taxon names  
+        ... cleaning up  
+Done.
+```
 
 This might be a good point for a tea break - I didn't time this but it
 was over ten minutes.
@@ -245,7 +267,9 @@ TESTDB = 'biosql_test'
 Change these to match your setup. You can then run the BioSQL unit tests
 as normal, e.g.
 
-`python run_tests.py test_BioSQL test_BioSQL_SeqIO`
+``` bash
+python run_tests.py test_BioSQL test_BioSQL_SeqIO
+```
 
 For PostgreSQL, use:
 
@@ -286,20 +310,26 @@ orchid namespace. You can check this at the command line:
 
 MySQL:
 
-`mysql --user=root bioseqdb -e "select * from biodatabase;"`
+``` bash
+mysql --user=root bioseqdb -e "select * from biodatabase;"
+```
 
 PostgreSQL:
 
-`psql -c "SELECT * FROM biodatabase;" bioseqdb`
+``` bash
+psql -c "SELECT * FROM biodatabase;" bioseqdb
+```
 
 Which should give something like this (assuming you haven't done any
 other testing yet):
 
-`+----------------+---------+-----------+------------------+`  
-`| biodatabase_id | name    | authority | description      |`  
-`+----------------+---------+-----------+------------------+`  
-`|              1 | orchids | NULL      | Just for testing |`  
-`+----------------+---------+-----------+------------------+`
+```
++----------------+---------+-----------+------------------+  
+| biodatabase_id | name    | authority | description      |  
++----------------+---------+-----------+------------------+  
+|              1 | orchids | NULL      | Just for testing |  
++----------------+---------+-----------+------------------+
+```
 
 Now that we have setup an *orchids* namespace within our *biosqldb*
 MySQL database, lets add some sequences to it.
@@ -327,12 +357,14 @@ handle.close()
 The expected output is below, note we have three records with a total of
 nine features:
 
-`AF191665.1 Opuntia marenae rpl16 gene; chloroplast gene for c...`  
-`Sequence length 902, 3 features, from: chloroplast Opuntia marenae`  
-`AF191664.1 Opuntia clavata rpl16 gene; chloroplast gene for c...`  
-`Sequence length 899, 3 features, from: chloroplast Grusonia clavata`  
-`AF191663.1 Opuntia bradtiana rpl16 gene; chloroplast gene for...`  
-`Sequence length 899, 3 features, from: chloroplast Opuntia bradtianaa`
+```
+AF191665.1 Opuntia marenae rpl16 gene; chloroplast gene for c...  
+Sequence length 902, 3 features, from: chloroplast Opuntia marenae  
+AF191664.1 Opuntia clavata rpl16 gene; chloroplast gene for c...  
+Sequence length 899, 3 features, from: chloroplast Grusonia clavata  
+AF191663.1 Opuntia bradtiana rpl16 gene; chloroplast gene for...  
+Sequence length 899, 3 features, from: chloroplast Opuntia bradtianaa
+```
 
 Now, instead of printing things on screen, let's add these three records
 to a new (empty) *orchid* database:
@@ -359,12 +391,16 @@ and you should see new rows in several tables.
 
 The *bioentry* and *biosequence* tables should have three new rows:
 
-`mysql --user=root bioseqdb -e "select * from bioentry;"`  
-`mysql --user=root bioseqdb -e "select * from biosequence;"`
+``` bash
+mysql --user=root bioseqdb -e "select * from bioentry;"  
+mysql --user=root bioseqdb -e "select * from biosequence;"
+```
 
 The should also be nine new features:
 
-`mysql --user=root bioseqdb -e "select * from seqfeature;"`
+``` bash
+mysql --user=root bioseqdb -e "select * from seqfeature;"
+```
 
 Next, we'll try and load these three records back from the database.
 
@@ -387,12 +423,14 @@ for identifier in ['6273291', '6273290', '6273289'] :
 
 Giving:
 
-`AF191665.1 Opuntia marenae rpl16 gene; chloroplast gene for c...`  
-`Sequence length 902`  
-`AF191664.1 Opuntia clavata rpl16 gene; chloroplast gene for c...`  
-`Sequence length 899`  
-`AF191663.1 Opuntia bradtiana rpl16 gene; chloroplast gene for...`  
-`Sequence length 899`
+```
+AF191665.1 Opuntia marenae rpl16 gene; chloroplast gene for c...  
+Sequence length 902  
+AF191664.1 Opuntia clavata rpl16 gene; chloroplast gene for c...  
+Sequence length 899  
+AF191663.1 Opuntia bradtiana rpl16 gene; chloroplast gene for...  
+Sequence length 899
+```
 
 The objects you get back from BioSQL act like a
 [SeqRecord](SeqRecord "wikilink") object with a [Seq](Seq "wikilink")
@@ -440,7 +478,9 @@ to apply this change.
 There should now be one less row in the *biodatabase* table, check this
 at the command line:
 
-`mysql --user=root bioseqdb -e "select * from biodatabase;"`
+``` bash
+mysql --user=root bioseqdb -e "select * from biodatabase;"
+```
 
 You can also check that the three orchid sequences have gone from the
 other tables.
@@ -461,13 +501,17 @@ MySQL Tips and Tricks
 If you are getting timeout errors, check to see if your SQL server has
 any orphaned threads.
 
-`mysql --user=root bioseqdb -e "SHOW INNODB STATUS\G" | grep "thread id"`
+``` bash
+mysql --user=root bioseqdb -e "SHOW INNODB STATUS\G" | grep "thread id"
+```
 
 And if there are, assuming you are the only person using this database,
 you might try killing them off using the thread id given by the above
 command:
 
-`mysql --user=root bioseqdb -e "KILL 123;"`
+``` bash
+mysql --user=root bioseqdb -e "KILL 123;"
+```
 
 Use at your own risk!
 

--- a/wiki/Converting_sequence_files.md
+++ b/wiki/Converting_sequence_files.md
@@ -42,18 +42,22 @@ print "Coverted %i records" % count
 In this example the GenBank file contained six records and started like
 this:
 
-`LOCUS       ATCOR66M      513 bp    mRNA            PLN       02-MAR-1992`  
-`DEFINITION  A.thaliana cor6.6 mRNA.`  
-`ACCESSION   X55053`  
-`VERSION     X55053.1  GI:16229`  
-`...`
+```
+LOCUS       ATCOR66M      513 bp    mRNA            PLN       02-MAR-1992
+DEFINITION  A.thaliana cor6.6 mRNA.  
+ACCESSION   X55053  
+VERSION     X55053.1  GI:16229  
+...
+```
 
 The resulting Fasta file also contains all six records and looks like
 this:
 
-`>X55053.1 A.thaliana cor6.6 mRNA.`  
-`AACAAAACACACATCAAAAACGATTTTACAAGAAAAAAATA...`  
-`...`
+```
+>X55053.1 A.thaliana cor6.6 mRNA.  
+AACAAAACACACATCAAAAACGATTTTACAAGAAAAAAATA...  
+...
+```
 
 Note that all the Fasta file can store is the identifier, description
 and sequence.

--- a/wiki/Download.md
+++ b/wiki/Download.md
@@ -55,14 +55,18 @@ Most **Linux** distributions will include an optional Biopython package
 automatically. If you have the Python package management tool pip
 installed, try:
 
-`pip install biopython`
+``` bash
+pip install biopython
+```
 
 Otherwise you typically install from source by downloading and
 uncompressing the archive, then running the commands:
 
-`python setup.py build`  
-`python setup.py test`  
-`sudo python setup.py install`
+``` bash
+python setup.py build  
+python setup.py test  
+sudo python setup.py install
+```
 
 Substitute python with your specific version, for example python3,
 jython or pypy.
@@ -72,7 +76,9 @@ need to have installed Apple's XCode tools from the App Store (it is a
 big download), and then the optional command line tools from within the
 XCode GUI's options menu, or on Mavericks by using the command:
 
-`xcode-select --install`
+``` bash
+xcode-select --install
+```
 
 If you have trouble, see the full installation instructions:
 
@@ -142,15 +148,21 @@ You should be able to install Biopython and its dependencies using the
 Synaptic GUI tool (on the main menu under System / Administration /
 Synaptic Package Manager), or at the command line using:
 
-`sudo apt-get install python-biopython`
+``` bash
+sudo apt-get install python-biopython
+```
 
 If you want the documentation and unit tests,
 
-`sudo apt-get install python-biopython-doc`
+``` bash
+sudo apt-get install python-biopython-doc
+```
 
 And if you want to use [BioSQL](BioSQL "wikilink"),
 
-`sudo apt-get install python-biopython-sql`
+``` bash
+sudo apt-get install python-biopython-sql
+```
 
 However, this will probably not be the latest release (see [Ubuntu
 listing here](http://packages.ubuntu.com/python-biopython), and [Debian
@@ -160,7 +172,9 @@ If you want the latest version of Biopython, you will need to install it
 from source. However, you should be able to automatically install the
 build dependencies with the following command:
 
-`sudo apt-get build-dep python-biopython`
+``` bash
+sudo apt-get build-dep python-biopython
+```
 
 ### Archlinux
 
@@ -169,11 +183,15 @@ repository](https://www.archlinux.org/packages/?q=biopython) as
 python-biopython (for Python 3) or python2-biopython (for Python 2) and
 can be installed using pacman:
 
-`  pacman -S python2-biopython`
+``` bash
+pacman -S python2-biopython
+```
 
 Or, for Python 3:
 
-`  pacman -S python-biopython`
+``` bash
+pacman -S python-biopython
+```
 
 ### Fedora
 
@@ -182,7 +200,9 @@ named
 [python-biopython](https://admin.fedoraproject.org/community/?package=python-biopython#package_maintenance),
 and can be installed using yum as root:
 
-`yum install python-biopython`
+``` bash
+yum install python-biopython
+```
 
 or via one of the GUI package management systems such as pirut and
 PackageKit (available in F-9 and later).
@@ -192,7 +212,9 @@ PackageKit (available in F-9 and later).
 Gentoo's portage tree contains an ebuild (sci-biology/biopython) which
 builds from source. To install it, open a terminal as root and run:
 
-`emerge -va biopython `
+``` bash
+emerge -va biopython
+```
 
 [Here](http://www.gentoo-portage.com/sci-biology/biopython) is a link to
 Biopython at [Gentoo-Portage](http://www.gentoo-portage.com) which shows
@@ -212,7 +234,9 @@ Supposing that you're familiar with this method and that you have an
 up-to-date ports tree, all you need to do is to execute the following
 commands as root:
 
-<bash> cd /usr/ports/biology/py-biopython make install clean </bash>
+``` bash
+cd /usr/ports/biology/py-biopython make install clean
+```
 
 Due to the great architecture of the ports system, this simple commands
 will automatically fetch and install Biopython (as well as its necessary

--- a/wiki/GitUsage.md
+++ b/wiki/GitUsage.md
@@ -61,16 +61,24 @@ in your package manager.
 
 #### Ubuntu/Debian
 
-You can install Git from the `git-core` package. e.g., `sudo` `apt-get`
-`install` `git-core`
+You can install Git from the `git-core` package. e.g.,
 
-You'll probably also want to install the following packages: `gitk`
-`git-gui` `git-doc`
+``` bash
+sudo apt-get install git-core
+```
+
+You'll probably also want to install the following packages: `gitk`,
+`git-gui`, and `git-doc`
 
 #### Redhat/Fedora/Mandriva
 
-git is also packaged in rpm-based linux distributions. `yum` `install`
-`gitk` should do the trick for you in any recent fedora/mandriva or
+git is also packaged in rpm-based linux distributions. 
+
+``` bash
+yum install gitk
+```
+
+should do the trick for you in any recent fedora/mandriva or
 derivatives
 
 ### Mac OS X
@@ -105,7 +113,12 @@ the `git` package under the "devel" category.
 Testing your git installation
 -----------------------------
 
-If your installation succeeded, you should be able to run `git` `--help`
+If your installation succeeded, you should be able to run
+
+``` bash
+git --help
+```
+
 in a console window to obtain information on git usage. If this fails,
 you should refer to git
 [documentation](http://git-scm.com/documentation) for troubleshooting.
@@ -162,7 +175,9 @@ Cloning Biopython directly
 Getting a copy of the repository (called "cloning" in Git terminology)
 without GitHub account is very simple:
 
-` git clone `[`git://github.com/biopython/biopython.git`](git://github.com/biopython/biopython.git)
+``` bash
+git clone git://github.com/biopython/biopython.git
+```
 
 This command creates a local copy of the entire Biopython repository on
 your machine (your own personal copy of the official repository with its
@@ -179,14 +194,14 @@ Forking Biopython with your GitHub account
 If you are logged in to GitHub, you can go to the Biopython repository
 page:
 
-[`http://github.com/biopython/biopython/tree/master`](http://github.com/biopython/biopython/tree/master)
+[http://github.com/biopython/biopython/tree/master](http://github.com/biopython/biopython/tree/master)
 
 and click on a button named 'Fork'. This will create a fork (basically a
 copy) of the official Biopython repository, publicly viewable on GitHub,
 but listed under your personal account. It should be visible under a URL
 that looks like this:
 
-[`http://github.com/yourusername/biopython`](http://github.com/yourusername/biopython)
+[http://github.com/yourusername/biopython](http://github.com/yourusername/biopython)
 
 Since your new Biopython repository is publicly visible, it's considered
 good practice to change the description and homepage fields to something
@@ -201,7 +216,9 @@ Now, assuming that you have git installed on your computer, execute the
 following commands locally on your machine. This "url" is given on the
 github page for your repository (if you are logged in):
 
-`git clone git@github.com:yourusername/biopython.git`
+``` bash
+git clone git@github.com:yourusername/biopython.git
+```
 
 Where <yourusername>, not surprisingly, stands for your GitHub username.
 You have just created a local copy of the Biopython repository on your
@@ -210,7 +227,9 @@ machine.
 You may want to also link your branch with the official distribution
 (see below on how to keep your copy in sync):
 
-`git remote add upstream `[`git://github.com/biopython/biopython.git`](git://github.com/biopython/biopython.git)
+``` bash
+git remote add upstream git://github.com/biopython/biopython.git
+```
 
 To add additional contributors to your repository on GitHub (i.e. people
 you want to be able to commit to it), select 'edit' and then add them to
@@ -221,8 +240,10 @@ If you haven't already done so, tell git your name and the email address
 you are using on github (so that your commits get matched up to your
 github account). For example,
 
-`git config --global user.name "David Jones"`  
-`git config --global user.email "d.jones@example.com"`
+``` bash
+git config --global user.name "David Jones"  
+git config --global user.email "d.jones@example.com"
+```
 
 Making changes locally
 ----------------------
@@ -235,25 +256,35 @@ better to manage and document.
 First of all, create a new branch to make some changes in, and switch to
 it:
 
-`git branch demo-branch`  
-`git checkout demo-branch`
+``` bash
+git branch demo-branch  
+git checkout demo-branch
+```
 
 To check which branch you are on, use:
 
-`git branch`
+``` bash
+git branch
+```
 
 Let us assume you've made changes to the file Bio/x.py. Try this:
 
-`git status`
+``` bash
+git status
+```
 
 So commit this change you first need to explicitly add this file to your
 change-set:
 
-`git add Bio/x.py`
+``` bash
+git add Bio/x.py
+```
 
 and now you commit:
 
-`git commit -m "added feature Y in Bio.x"`
+``` bash
+git commit -m "added feature Y in Bio.x"
+```
 
 Your commits in Git are local, i.e. they affect only your working branch
 on your computer, and not the whole Biopython tree or even your fork on
@@ -269,7 +300,9 @@ branch, you can very easily make your changes available for others.
 Once you think your changes are stable and should be reviewed by others,
 you can push your changes back to the GitHub server:
 
-`git push origin demo-branch`
+``` bash
+git push origin demo-branch
+```
 
 *This will not work if you have cloned directly from the official
 Biopython branch, since only the core developers will have write access
@@ -286,12 +319,16 @@ official Biopython branch) to your repository.
 
 Assuming you have issued this command (you only need to do this once):
 
-`git remote add upstream `[`git://github.com/biopython/biopython.git`](git://github.com/biopython/biopython.git)
+``` bash
+git remote add upstream git://github.com/biopython/biopython.git
+```
 
 Then all you need to do is:
 
-`git checkout master`  
-`git pull upstream master`
+``` bash
+git checkout master  
+git pull upstream master
+```
 
 Provided you never commit any change to your local **master** branch,
 this should always be a simple *fast forward* merge without any
@@ -302,7 +339,9 @@ offline).
 If you have your repository hosted online (e.g. at github), then push
 the updated master branch there:
 
-`git push origin master`
+``` bash
+git push origin master
+```
 
 Submitting changes for inclusion in Biopython
 ---------------------------------------------
@@ -342,77 +381,93 @@ core developers, or anyone accepting changes on a branch.
 For example, suppose Eric has some interesting changes on his public
 repository:
 
-[`git://github.com/etal/biopython.git`](git://github.com/etal/biopython.git)
+[git://github.com/etal/biopython.git](git://github.com/etal/biopython.git)
 
 You must tell git about this by creating a reference to this remote
 repository:
 
-`$ git remote add eric `[`git://github.com/etal/biopython.git`](git://github.com/etal/biopython.git)
+``` bash
+git remote add eric git://github.com/etal/biopython.git
+```
 
 Now we can fetch *all* of Eric's public repository with one line:
 
-`$ git fetch eric`  
-`remote: Counting objects: 138, done.`  
-`remote: Compressing objects: 100% (105/105), done.`  
-`remote: Total 105 (delta 77), reused 0 (delta 0)`  
-`Receiving objects: 100% (105/105), 27.53 KiB, done.`  
-`Resolving deltas: 100% (77/77), completed with 24 local objects.`  
-`From `[`git://github.com/etal/biopython`](git://github.com/etal/biopython)  
-` * [new branch]      bug2754    -> eric/bug2754`  
-` * [new branch]      master     -> eric/master`  
-` * [new branch]      pdbtidy    -> eric/pdbtidy`  
-` * [new branch]      phyloxml   -> eric/phyloxml`
+``` bash
+git fetch eric  
+remote: Counting objects: 138, done.  
+remote: Compressing objects: 100% (105/105), done. 
+remote: Total 105 (delta 77), reused 0 (delta 0)  
+Receiving objects: 100% (105/105), 27.53 KiB, done.  
+Resolving deltas: 100% (77/77), completed with 24 local objects.  
+From git://github.com/etal/biopython  
+ * [new branch]      bug2754    -> eric/bug2754  
+ * [new branch]      master     -> eric/master  
+ * [new branch]      pdbtidy    -> eric/pdbtidy  
+ * [new branch]      phyloxml   -> eric/phyloxml
+```
 
 Now we can run a diff between any of our own branches and any of Eric's
 branches. You can list your own branches with:
 
-`$ git branch`  
-`* master`  
-`  ...`
+``` bash
+git branch  
+* master  
+  ...
+```
 
 Remember the asterisk shows which branch is currently checked out.
 
 To list the remote branches you have setup:
 
-`$ git branch -r`  
-`  eric/bug2754`  
-`  eric/master`  
-`  eric/pdbtidy`  
-`  eric/phyloxml`  
-`  upstream/master`  
-`  origin/HEAD`  
-`  origin/master`  
-`  ...`
+``` bash
+git branch -r  
+ eric/bug2754  
+ eric/master  
+ eric/pdbtidy  
+ eric/phyloxml  
+ upstream/master  
+ origin/HEAD  
+ origin/master  
+ ...
+```
 
 For example, to show the difference between your **master** branch and
 Eric's **master** branch:
 
-`$ git diff master eric/master`  
-`...`
+``` bash
+git diff master eric/master  
+...
+```
 
 If you are both keeping your **master** branch in sync with the upstream
 Biopython repository, then his **master** branch won't be very
 interesting. Instead, try:
 
-`$ git diff master eric/pdbtidy`  
-`...`
+``` bash
+git diff master eric/pdbtidy  
+...
+```
 
 You might now want to merge in (some) of Eric's changes to a new branch
 on your local repository.
 
 If you later want to remove the reference to this particular branch:
 
-`$ git branch -r -d eric/pdbtidy`  
-`Deleted remote branch eric/pdbtidy (79b5974)`
+``` bash
+git branch -r -d eric/pdbtidy  
+Deleted remote branch eric/pdbtidy (79b5974)
+```
 
 Or, to delete the references to all of Eric's branches:
 
-`$ git remote rm eric`  
-`$ git branch -r`  
-`  upstream/master`  
-`  origin/HEAD`  
-`  origin/master`  
-`  ...`
+``` bash
+git remote rm eric  
+git branch -r  
+  upstream/master  
+  origin/HEAD  
+  origin/master  
+  ...
+```
 
 Alternatively, from within GitHub you can use the fork-queue to cherry
 pick commits from other people's forked branches. See [this github blog
@@ -445,7 +500,9 @@ Once you are a collaborator, you can pull biopython official branch
 using the private url. If you want to make a new repository (linked to
 the main branch), you can just clone it:
 
-`git clone git@github.com:biopython/biopython.git`
+``` bash
+git clone git@github.com:biopython/biopython.git
+```
 
 It creates a new directory "biopython" with a local copy of the official
 branch. It also sets the "origin" to the github copy This is the
@@ -459,11 +516,13 @@ with the git "remote command"... but we'll not cover that here.
 In the following sections, we assume you have followed the recommended
 scenario and you have the following entries in your .git/config file:
 
-`[remote "origin"]`  
-`       url = git@github.com:biopython/biopython.git`  
-`       `  
-`[branch "master"]`  
-`       remote = origin`
+``` 
+[remote "origin"]  
+       url = git@github.com:biopython/biopython.git  
+         
+[branch "master"]  
+       remote = origin
+```
 
 Committing a patch
 ------------------
@@ -471,25 +530,35 @@ Committing a patch
 If you are committing from a patch, it's also quite easy. First make
 sure you are up to date with official branch:
 
-`git checkout master `  
-`git pull origin`
+``` bash
+git checkout master   
+git pull origin
+```
 
 Then do your changes, i.e. apply the patch:
 
-`patch -r someones_cool_feature.diff`
+``` bash
+patch -r someones_cool_feature.diff
+```
 
 If you see that there were some files added to the tree, please add them
 to git:
 
-`git add Bio/Tests/some_new_file`
+``` bash
+git add Bio/Tests/some_new_file
+```
 
 Then make a commit (after adding files):
 
-`git commit -a -m "committed a patch from a kind contributor adding feature X"`
+``` bash
+git commit -a -m "committed a patch from a kind contributor adding feature X"
+```
 
 After your changes are committed, you can push to github:
 
-`git push origin`
+``` bash
+git push origin
+```
 
 Commiting from someone's git branch
 -----------------------------------
@@ -501,39 +570,51 @@ giving you a URL. Typically this will be on github (but it may be any
 public git url). Let us assume that the url is (which happens to be my
 clone of biopython):
 
-[`git://github.com/barwil/biopython.git`](git://github.com/barwil/biopython.git)
+[git://github.com/barwil/biopython.git](git://github.com/barwil/biopython.git)
 
 First, you need to get the code from this repository:
 
-`git remote add Bartek  `[`git://github.com/barwil/biopython.git`](git://github.com/barwil/biopython.git)  
-`git fetch Bartek`
+``` bash
+git remote add Bartek git://github.com/barwil/biopython.git  
+git fetch Bartek
+```
 
 Then you can see what branches are there:
 
-`$ git branch -r`  
-` Bartek/master`  
-` Bartek/motif_docs`  
-` Bartek/test-branch`
+``` bash
+git branch -r  
+ Bartek/master  
+ Bartek/motif_docs  
+ Bartek/test-branch
+```
 
 Let's say you want to merge changes from test-branch. You need to make
 sure you are up to date with the official branch:
 
-`git checkout master `  
-`git pull origin`
+``` bash
+git checkout master   
+git pull origin
+```
 
 And then you can do the actual merge:
 
-`git pull Bartek test-branch`
+``` bash
+git pull Bartek test-branch
+```
 
 And (assuming you are OK with the results of git diff and git status),
 you can push to the public repository on github (please don't try that
 with this exemplary data):
 
-`git push origin`
+``` bash
+git push origin
+```
 
 After you're done, you can remove the reference to the remote repo:
 
-`git remote rm Bartek`
+``` bash
+git remote rm Bartek
+```
 
 Tagging the official branch
 ---------------------------
@@ -543,16 +624,22 @@ usually done to mark a new release), you need to follow these steps:
 
 First make sure you are up to date with official branch:
 
-`git checkout master `  
-`git pull origin`
+``` bash
+git checkout master   
+git pull origin
+```
 
 Then add the actual tag:
 
-`git tag new_release`
+``` bash
+git tag new_release
+```
 
 And push it to github:
 
-`git push --tags origin master`
+``` bash
+git push --tags origin master
+```
 
 Additional Resources
 ====================

--- a/wiki/Reading_from_unix_pipes.md
+++ b/wiki/Reading_from_unix_pipes.md
@@ -38,8 +38,9 @@ command or program. For example, the following shell command can be used
 to extract the compressed sequence and pipe it to the script
 (solexa2sanger\_fq.py).
 
-<bash> gunzip -c some\_solexa.fastq.gz | python solexa2sanger\_fq.py
-</bash>
+``` bash
+gunzip -c some_solexa.fastq.gz | python solexa2sanger_fq.py
+```
 
 This will write the sequence in Sanger FASTQ format to stdout - in this
 case the screen.
@@ -51,8 +52,9 @@ program's stdout to a file. In this example, the python script is fed
 its data redirected from an input file, and the output which would have
 been printed to screen is instead redirected to an output file:
 
-<bash> python solexa2sanger\_fq.py &lt; some\_solexa.fastq &gt;
-some\_phred.fastq </bash>
+``` bash
+python solexa2sanger_fq.py < some_solexa.fastq > some_phred.fastq
+```
 
 Redirection can also be used to redirect a program or command's stderr
 to a file. Further examples of using redirection can be found

--- a/wiki/Reading_large_PDB_files.md
+++ b/wiki/Reading_large_PDB_files.md
@@ -11,10 +11,12 @@ produced by molecular dynamics (MD) codes then one quickly runs into
 problems with missing atoms on reading. The typical error message says
 that atoms will be missing:
 
-`WARNING: Residue (' ', 1, ' ') redefined at line 31.`  
-`PDBConstructionException: Blank altlocs in duplicate residue SOL (' ', 1, ' ') at line 31.`  
-`Exception ignored.`  
-`Some atoms or residues will be missing in the data structure.`
+```
+WARNING: Residue (' ', 1, ' ') redefined at line 31.  
+PDBConstructionException: Blank altlocs in duplicate residue SOL (' ', 1, ' ') at line 31.  
+Exception ignored.  
+Some atoms or residues will be missing in the data structure.
+```
 
 The problem is simply that these files can be large with hundreds of
 thousands of atoms and residues (for instance, each water molecule is a
@@ -25,7 +27,7 @@ appropriate columns of the
 record to accommodate atom numbers (*serial*) &gt;99,999 and residue
 numbers (*resSeq*) &gt; 9999. Thus, these numbers are simply written
 modulo 100,000 (*serial*) or modulo 10,000 (*resSeq*). This creates
-duplicate entries in the chain and the Bio.PDB.PDBParser (or rather, the
+duplicate entries in the chain and the `Bio.PDB.PDBParser` (or rather, the
 StructureBuilder) complains. The effect is that not all atoms are read.
 
 The [code below](#Classes "wikilink") derives a new class from
@@ -183,7 +185,7 @@ def get_structure(pdbfile,pdbid='system'):
 See Also
 --------
 
-The SloppyStructureBuilder() was used as the basis for a small python
+The `SloppyStructureBuilder()` was used as the basis for a small python
 module
 [edPDB](http://sbcb.bioch.ox.ac.uk/oliver/software/GromacsWrapper/html/edpdb.html)
 to edit PDB files in preparation for MD simulations.

--- a/wiki/SeqIO.md
+++ b/wiki/SeqIO.md
@@ -282,17 +282,21 @@ print "Converted %i records" % count
 
 In this example the GenBank file started like this:
 
-`LOCUS       ATCOR66M      513 bp    mRNA            PLN       02-MAR-1992`  
-`DEFINITION  A.thaliana cor6.6 mRNA.`  
-`ACCESSION   X55053`  
-`VERSION     X55053.1  GI:16229`  
-`...`
+```
+LOCUS       ATCOR66M      513 bp    mRNA            PLN       02-MAR-1992  
+DEFINITION  A.thaliana cor6.6 mRNA.  
+ACCESSION   X55053  
+VERSION     X55053.1  GI:16229  
+...
+```
 
 The resulting Fasta file looks like this:
 
-`>X55053.1 A.thaliana cor6.6 mRNA.`  
-`AACAAAACACACATCAAAAACGATTTTACAAGAAAAAAATA...`  
-`...`
+```
+>X55053.1 A.thaliana cor6.6 mRNA.  
+AACAAAACACACATCAAAAACGATTTTACAAGAAAAAAATA...  
+...
+```
 
 Note that all the Fasta file can store is the identifier, description
 and sequence.
@@ -396,10 +400,12 @@ for record in SeqIO.parse(open("ls_orchid.gbk"), "genbank") :
 
 You should get this output:
 
-`Z78533.1 JUEoWn6DPhgZ9nAyowsgtoD9TTo`  
-`Z78532.1 MN/s0q9zDoCVEEc+k/IFwCNF2pY`  
-`...`  
-`Z78439.1 H+JfaShya/4yyAj7IbMqgNkxdxQ`
+```
+Z78533.1 JUEoWn6DPhgZ9nAyowsgtoD9TTo  
+Z78532.1 MN/s0q9zDoCVEEc+k/IFwCNF2pY  
+... 
+Z78439.1 H+JfaShya/4yyAj7IbMqgNkxdxQ
+```
 
 Now lets use the checksum function and **Bio.SeqIO.to\_dict()** to build
 a [SeqRecord](SeqRecord "wikilink") dictionary using the SEGUID as the
@@ -420,8 +426,10 @@ print record.description
 
 Giving this output:
 
-`Z78439.1 `  
-`P.barbatum 5.8S rRNA gene and ITS1 and ITS2 DNA.`
+```
+Z78439.1   
+P.barbatum 5.8S rRNA gene and ITS1 and ITS2 DNA.
+```
 
 ### Random subsequences
 
@@ -456,17 +464,19 @@ output_handle.close()
 
 That should give something like this as the output file,
 
-`>fragment_1 `  
-`TGGGCCTCATATTTATCCTATATACCATGTTCGTATGGTGGCGCGATGTTCTACGTGAAT`  
-`CCACGTTCGAAGGACATCATACCAAAGTCGTACAATTAGGACCTCGATATGGTTTTATTC`  
-`TGTTTATCGTATCGGAGGTTATGTTCTTTTTTGCTCTTTTTCGGGCTTCTTCTCATTCTT`  
-`CTTTGGCACCTACGGTAGAG`  
-`...`  
-`>fragment_500 `  
-`ACCCAGTGCCGCTACCCACTTCTACTAAGGCTGAGCTTAATAGGAGCAAGAGACTTGGAG`  
-`GCAACAACCAGAATGAAATATTATTTAATCGTGGAAATGCCATGTCAGGCGCACCTATCA`  
-`GAATCGGAACAGACCAATTACCAGATCCACCTATCATCGCCGGCATAACCATAAAAAAGA`  
-`TCATTAAAAAAGCGTGAGCC`
+```
+>fragment_1  
+TGGGCCTCATATTTATCCTATATACCATGTTCGTATGGTGGCGCGATGTTCTACGTGAAT  
+CCACGTTCGAAGGACATCATACCAAAGTCGTACAATTAGGACCTCGATATGGTTTTATTC  
+TGTTTATCGTATCGGAGGTTATGTTCTTTTTTGCTCTTTTTCGGGCTTCTTCTCATTCTT  
+CTTTGGCACCTACGGTAGAG 
+...  
+>fragment_500  
+ACCCAGTGCCGCTACCCACTTCTACTAAGGCTGAGCTTAATAGGAGCAAGAGACTTGGAG  
+GCAACAACCAGAATGAAATATTATTTAATCGTGGAAATGCCATGTCAGGCGCACCTATCA  
+GAATCGGAACAGACCAATTACCAGATCCACCTATCATCGCCGGCATAACCATAAAAAAGA  
+TCATTAAAAAAGCGTGAGCC
+```
 
 ### Writing to a string
 

--- a/wiki/SeqRecord.md
+++ b/wiki/SeqRecord.md
@@ -41,12 +41,14 @@ for index, record in enumerate(SeqIO.parse(open("ls_orchid.gbk"), "genbank")):
 And this is some of the output. Remember python likes to count from
 zero, so the 94 records in this file have been labelled 0 to 93:
 
-`index 0, ID = Z78533.1, length 740, with 5 features`  
-`index 1, ID = Z78532.1, length 753, with 5 features`  
-`index 2, ID = Z78531.1, length 748, with 5 features`  
-`...`  
-`index 92, ID = Z78440.1, length 744, with 5 features`  
-`index 93, ID = Z78439.1, length 592, with 5 features`
+```
+index 0, ID = Z78533.1, length 740, with 5 features  
+index 1, ID = Z78532.1, length 753, with 5 features  
+index 2, ID = Z78531.1, length 748, with 5 features  
+...  
+index 92, ID = Z78440.1, length 744, with 5 features  
+index 93, ID = Z78439.1, length 592, with 5 features
+```
 
 Lets look in a little more detail at the final record:
 
@@ -57,19 +59,21 @@ print record
 That should give you a hint of the sort of information held in this
 object:
 
-`ID: Z78439.1`  
-`Name: Z78439`  
-`Description: P.barbatum 5.8S rRNA gene and ITS1 and ITS2 DNA.`  
-`Number of features: 5`  
-`/source=Paphiopedilum barbatum`  
-`/taxonomy=['Eukaryota', 'Viridiplantae', 'Streptophyta', 'Embryophyta', ..., 'Paphiopedilum']`  
-`/keywords=['5.8S ribosomal RNA', '5.8S rRNA gene', 'internal transcribed spacer', 'ITS1', 'ITS2']`  
-`/references=[`<Bio.SeqFeature.Reference ...>`, `<Bio.SeqFeature.Reference ...>`]`  
-`/data_file_division=PLN`  
-`/date=30-NOV-2006`  
-`/organism=Paphiopedilum barbatum`  
-`/gi=2765564`  
-`Seq('CATTGTTGAGATCACATAATAATTGATCGAGTTAATCTGGAGGATCTGTTTACTTTGGTC ...', IUPACAmbiguousDNA())`
+```
+ID: Z78439.1  
+Name: Z78439  
+Description: P.barbatum 5.8S rRNA gene and ITS1 and ITS2 DNA. 
+Number of features: 5 
+/source=Paphiopedilum barbatum
+/taxonomy=['Eukaryota', 'Viridiplantae', 'Streptophyta', 'Embryophyta', ..., 'Paphiopedilum']
+/keywords=['5.8S ribosomal RNA', '5.8S rRNA gene', 'internal transcribed spacer', 'ITS1', 'ITS2']
+/references=[`<Bio.SeqFeature.Reference ...>`, `<Bio.SeqFeature.Reference ...>`]
+/data_file_division=PLN 
+/date=30-NOV-2006  
+/organism=Paphiopedilum barbatum  
+/gi=2765564 
+Seq('CATTGTTGAGATCACATAATAATTGATCGAGTTAATCTGGAGGATCTGTTTACTTTGGTC ...', IUPACAmbiguousDNA())
+```
 
 Lets look a little more closely... and use python's **dir()** function
 to find out more about the SeqRecord object and what it does:
@@ -169,17 +173,19 @@ example:
 
 This should give:
 
-`>Z78439.1 P.barbatum 5.8S rRNA gene and ITS1 and ITS2 DNA.`  
-`CATTGTTGAGATCACATAATAATTGATCGAGTTAATCTGGAGGATCTGTTTACTTTGGTC`  
-`ACCCATGGGCATTTGCTGTTGAAGTGACCTAGATTTGCCATCGAGCCTCCTTGGGAGCTT`  
-`TCTTGTTGGCGAGATCTAAACCCCTGCCCGGCGGAGTTGGGCGCCAAGTCATATGACACA`  
-`TAATTGGTGAAGGGGGTGGTAATCCTGCCCTGACCCTCCCCAAATTATTTTTTTAACAAC`  
-`TCTCAGCAACGGATATCTCGGCTCTTGCATCGATGAAGAACGCAGCGAAATGCGATAATG`  
-`GTGTGAATTGCAGAATCCCGTGAACATCGAGTCTTTGAACGCAAGTTGCGCCCGAGGCCA`  
-`TCAGGCCAAGGGCACGCCTGCCTGGGCATTGCGAGTCATATCTCTCCCTTAATGAGGCTG`  
-`TCCATACATACTGTTCAGCCGGTGCGGATGTGAGTTTGGCCCCTTGTTCTTTGGTACGGG`  
-`GGGTCTAAGAGCTGCATGGGCTTTGGATGGTCCTAAATACGGAAAGAGGTGGACGAACTA`  
-`TGCTACAACAAAATTGTTGTGCAAATGCCCCGGTTGGCCGTTTAGTTGGGCC`
+```
+>Z78439.1 P.barbatum 5.8S rRNA gene and ITS1 and ITS2 DNA.  
+CATTGTTGAGATCACATAATAATTGATCGAGTTAATCTGGAGGATCTGTTTACTTTGGTC  
+ACCCATGGGCATTTGCTGTTGAAGTGACCTAGATTTGCCATCGAGCCTCCTTGGGAGCTT  
+TCTTGTTGGCGAGATCTAAACCCCTGCCCGGCGGAGTTGGGCGCCAAGTCATATGACACA  
+TAATTGGTGAAGGGGGTGGTAATCCTGCCCTGACCCTCCCCAAATTATTTTTTTAACAAC  
+TCTCAGCAACGGATATCTCGGCTCTTGCATCGATGAAGAACGCAGCGAAATGCGATAATG  
+GTGTGAATTGCAGAATCCCGTGAACATCGAGTCTTTGAACGCAAGTTGCGCCCGAGGCCA  
+TCAGGCCAAGGGCACGCCTGCCTGGGCATTGCGAGTCATATCTCTCCCTTAATGAGGCTG  
+TCCATACATACTGTTCAGCCGGTGCGGATGTGAGTTTGGCCCCTTGTTCTTTGGTACGGG  
+GGGTCTAAGAGCTGCATGGGCTTTGGATGGTCCTAAATACGGAAAGAGGTGGACGAACTA  
+TGCTACAACAAAATTGTTGTGCAAATGCCCCGGTTGGCCGTTTAGTTGGGCC
+```
 
 If you are using Biopython 1.50 or later, there will also be a
 **letter\_annotations** property. Again this is a dictionary but for
@@ -216,11 +222,13 @@ print record
 
 This would give the following output:
 
-`ID: YP_025292.1`  
-`Name: HokC`  
-`Description: toxic membrane protein, small`  
-`Number of features: 0`  
-`Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF', IUPACProtein())`
+```
+ID: YP_025292.1  
+Name: HokC  
+Description: toxic membrane protein, small  
+Number of features: 0  
+Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF', IUPACProtein())
+```
 
 You could then pass this new record to
 [Bio.SeqIO.write(...)](SeqIO "wikilink") to save it to disk.

--- a/wiki/Sequence_Cleaner.md
+++ b/wiki/Sequence_Cleaner.md
@@ -37,11 +37,14 @@ def sequence_cleaner(fasta_file,min_length=0,por_n=100):
         #Take the current sequence
         sequence=str(seq_record.seq).upper()
         #Check if the current sequence is according to the user parameters
-        if (len(sequence)>=min_length and (float(sequence.count("N"))/float(len(sequence)))*100<=por_n):
-       # If the sequence passed in the test "is It clean?" and It isnt in the hash table , the sequence and Its id are going to be in the hash
+        if (len(sequence)>=min_length and 
+		   (float(sequence.count("N"))/float(len(sequence)))*100<=por_n):
+        # If the sequence passed in the test "is It clean?" and It isnt in the
+        # hash table , the sequence and Its id are going to be in the hash
             if sequence not in sequences:
                 sequences[sequence]=seq_record.id
-       #If It is already in the hash table, We're just gonna concatenate the ID of the current sequence to another one that is already in the hash table
+       # If It is already in the hash table, We're just gonna concatenate the ID
+       # of the current sequence to another one that is already in the hash table
             else:
                 sequences[sequence]+="_"+seq_record.id
  
@@ -66,26 +69,34 @@ try:
     elif len(userParameters)==2:
         sequence_cleaner(userParameters[0],float(userParameters[1]))
     elif len(userParameters)==3:
-        sequence_cleaner(userParameters[0],float(userParameters[1]),float(userParameters[2]))
+        sequence_cleaner(userParameters[0],float(userParameters[1]),
+		                 float(userParameters[2]))
     else:
         print "There is a problem!"
 except:
     print "There is a problem!"
-
-    
-#python sequence_cleaner.py Aip_coral.fasta 10 10
 ```
 
-Using command line, you should run python sequence\_cleaner.py
-INPUT-(1st) MIN\_LENGHT-(2nd) MIN\_%-(3rd) - there are 3 basic
-parameters:
+Using the command line, you should run: 
 
-`        #1st: your fasta file `  
-`        #2nd: the user defines the minimum length (default value 0 (It means you don't have to care about the minimum length)`  
-`        #3rd: the user defines the % of N is allowed (default value 100 (all sequences with 'N' will be in your ouput), `  
-`              set value to 0 if you want no sequences with "N" in your output)`
+``` bash
+python sequence_cleaner.py input[1] min_length[2] min[3]
+```
 
-`        For exemple: python sequence_cleaner.py Aip_coral.fasta 10 10`
+There are 3 basic parameters:
+
+-   \[1\]: your fasta file
+-   \[2\]: the user defines the minimum length. Default value 0, it means you
+    don't have to care about the minimum length
+-   \[3\]: the user defines the % of N is allowed. Default value 100, all
+    sequences with 'N' will be in your ouput, set value to 0 if you want no
+    sequences with "N" in your output
+
+For example:
+
+``` bash
+python sequence_cleaner.py Aip_coral.fasta 10 10
+```
 
 FYI: if you don't care about the 2nd and the 3rd parameters you are just
 gonna remove the duplicate sequences

--- a/wiki/Split_large_file.md
+++ b/wiki/Split_large_file.md
@@ -72,16 +72,18 @@ for i, batch in enumerate(batch_iterator(record_iter, 10000)) :
 
 And the output:
 
-`Wrote 10000 records to group_1.fastq`  
-`Wrote 10000 records to group_2.fastq`  
-`Wrote 10000 records to group_3.fastq`  
-`Wrote 10000 records to group_4.fastq`  
-`Wrote 10000 records to group_5.fastq`  
-`Wrote 10000 records to group_6.fastq`  
-`Wrote 10000 records to group_7.fastq`  
-`Wrote 10000 records to group_8.fastq`  
-`Wrote 10000 records to group_9.fastq`  
-`Wrote 4696 records to group_10.fastq`
+```
+Wrote 10000 records to group_1.fastq  
+Wrote 10000 records to group_2.fastq  
+Wrote 10000 records to group_3.fastq  
+Wrote 10000 records to group_4.fastq  
+Wrote 10000 records to group_5.fastq  
+Wrote 10000 records to group_6.fastq  
+Wrote 10000 records to group_7.fastq  
+Wrote 10000 records to group_8.fastq  
+Wrote 10000 records to group_9.fastq  
+Wrote 4696 records to group_10.fastq
+```
 
 You can modify this recipe to use any input and output formats supported
 by [Bio.SeqIO](SeqIO "wikilink"), for example to break up a large FASTA

--- a/wiki/The_Biopython_Structural_Bioinformatics_FAQ.md
+++ b/wiki/The_Biopython_Structural_Bioinformatics_FAQ.md
@@ -249,8 +249,10 @@ for donating this module.
 The following commands will store all PDB files in the `/data/pdb`
 directory:
 
-`python` `PDBList.py` `all` `/data/pdb` `python` `PDBList.py` `all`
-`/data/pdb` `-d`
+``` python
+python PDBList.py all /data/pdb
+python PDBList.py all /data/pdb -d
+```
 
 The API method for this is called `download_entire_pdb`. Adding the `-d`
 option will store all files in the same directory. Otherwise, they are
@@ -325,7 +327,7 @@ also correctly interpreted.
 
 #### Can I write PDB files?
 
-Use the PDBIO class for this. It's easy to write out specific parts of a
+Use the `PDBIO` class for this. It's easy to write out specific parts of a
 structure too, of course.
 
 Example: saving a structure
@@ -510,8 +512,8 @@ id is a tuple with three elements:
     as follows: Thr 80 A, Ser 80 B, Asn 81. In this way the residue
     numbering scheme stays in tune with that of the wild type structure.
 
-The id of the above glucose residue would thus be `('H_GLC',` `100,`
-`'A')`. If the hetero-flag and insertion code are blank, the sequence
+The id of the above glucose residue would thus be `('H_GLC', 100, 'A')`.
+If the hetero-flag and insertion code are blank, the sequence
 identifier alone can be used:
 
 ``` python
@@ -897,8 +899,8 @@ cb = cb_at_origin + ca
 This example shows that it's possible to do some quite nontrivial vector
 operations on atomic data, which can be quite useful. In addition to all
 the usual vector operations (cross (use `**`), and dot (use `*`)
-product, angle, norm, etc.) and the above mentioned <code>rotaxis
-function, the <code>Vector module also has methods to rotate (`rotmat`)
+product, angle, norm, etc.) and the above mentioned `rotaxis`
+function, the `Vector` module also has methods to rotate (`rotmat`)
 or reflect (`refmat`) one vector on top of another.
 
 ### Manipulating the structure


### PR DESCRIPTION
At the moment, multi-line command line examples and output of code is often formatted as inline code, which doesn' look so nice (different length, white horizontal stripes), e.g. in SeqIO:

![example1](https://cloud.githubusercontent.com/assets/4503120/14586123/6a98ced6-048e-11e6-8395-5d179143c1ca.png)

Here I formatted in 11 files where I found such things code output and command-line examples as block code, e.g.:

![example2](https://cloud.githubusercontent.com/assets/4503120/14586124/784e11d0-048e-11e6-962e-eaa72ec8ca74.png)