### PR TITLE
Sidebar styling

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -13,7 +13,7 @@
       -->
       <div class="sidebar-logo">
         <a href="{{ site.baseurl }}">
-          <img src="/biopython_grey.png" alt="Biopython Logo" title="" width="100%"/>
+          <img src="/biopython_grey.png" alt="Biopython Logo" title="Biopython Home" width="100%"/>
         </a>
       </div>
       <p class="lead">{{ site.description }}</p>
@@ -43,9 +43,11 @@
       <a class="sidebar-nav-item" href="{{ site.github.repo }}/archive/v{{ site.version }}.zip">Download</a>
       -->
       <a class="sidebar-nav-item" href="{{ site.github.repo }}">GitHub project</a>
-      <span class="sidebar-nav-item">Currently v{{ site.version }}</span>
     </nav>
-
-    <p>&copy; {{ site.time | date: '%Y' }}. All rights reserved.</p>
+    
+  </div>
+  <div class="sidebar-footer">
+      Biopython version {{ site.version }}<br>
+      &copy; {{ site.time | date: '%Y' }}. All rights reserved.
   </div>
 </div>

--- a/css/hyde.css
+++ b/css/hyde.css
@@ -55,7 +55,7 @@ html {
 
 .sidebar {
   text-align: center;
-  padding: 2rem 1rem;
+  padding: 0.5rem 1rem;
   color: rgba(255,255,255,.5);
   background-color: #10100F;
 }
@@ -67,6 +67,23 @@ html {
     bottom: 0;
     width: 18rem;
     text-align: left;
+    padding: 2rem 1rem;
+  }
+  .sidebar-nav {
+    margin-bottom: 1rem;
+  }
+  .sidebar-nav-item {
+    display: block;
+    line-height: 1.75;
+  }
+  .sidebar-footer {
+    position: absolute;
+    bottom: 5px;
+    padding: 1rem;
+  }
+  .container {
+    padding-left: 1rem;
+    padding-right: 1rem;
   }
 }
 
@@ -85,11 +102,10 @@ html {
 
 /* Sidebar nav */
 .sidebar-nav {
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 }
 .sidebar-nav-item {
-  display: block;
-  line-height: 1.75;
+  padding-right: 0.5rem
 }
 a.sidebar-nav-item:hover,
 a.sidebar-nav-item:focus {
@@ -122,8 +138,10 @@ a.sidebar-nav-item:focus {
  */
 
 .content {
-  padding-top:    4rem;
-  padding-bottom: 4rem;
+  padding-top:    2rem;
+  padding-bottom: 1rem;
+  padding-left:   1rem;
+  padding-right:  1rem;
 }
 
 @media (min-width: 48em) {
@@ -131,6 +149,8 @@ a.sidebar-nav-item:focus {
     max-width: 46rem;
     margin-left: 20rem;
     margin-right: 2rem;
+    padding-top: 4rem;
+    padding-bottom: 1rem;
   }
 }
 
@@ -138,6 +158,8 @@ a.sidebar-nav-item:focus {
   .content {
     margin-left: 22rem;
     margin-right: 4rem;
+    padding-top: 4rem;
+    padding-bottom: 1rem;
   }
 }
 

--- a/css/poole.css
+++ b/css/poole.css
@@ -293,8 +293,6 @@ tbody tr:nth-child(odd) th {
 
 .container {
   max-width: 38rem;
-  padding-left:  1rem;
-  padding-right: 1rem;
   margin-left:  auto;
   margin-right: auto;
 }


### PR DESCRIPTION
- as discussed on #15
- put Biopython version and copyright to bottom of sidebar (away from navigation)
- optimized sidebar for small devices when displayed as 'top'-bar
- used old logo, @peterjc will commit transparent logo from @widdowquinn 