### PR TITLE
Fixed imports for xpdb 

### DIFF
--- a/wiki/Reading_large_PDB_files.md
+++ b/wiki/Reading_large_PDB_files.md
@@ -78,6 +78,7 @@ somewhere on your `PYTHONPATH`.
 import sys
 import Bio.PDB
 import Bio.PDB.StructureBuilder
+from Bio.PDB import Residue
 
 
 class SloppyStructureBuilder(Bio.PDB.StructureBuilder.StructureBuilder):
@@ -145,7 +146,7 @@ class SloppyStructureBuilder(Bio.PDB.StructureBuilder.StructureBuilder):
                                  % (field, resseq, icode, self.line_counter) +
                                  ".... assigning new resid %d.\n"
                                  % self.max_resseq)
-        residue = Residue(res_id, resname, self.segid)
+        residue = Residue.Residue(res_id, resname, self.segid)
         self.chain.add(residue)
         self.residue = residue
 


### PR DESCRIPTION
The recipe did not work as published; it runs into errors trying to find Residue. This can be fixed by adding in the correct imports, as explained by Peter Cock and Markus Piotrowski in http://lists.open-bio.org/pipermail/biopython/2016-May/015944.html.