### PR TITLE
More prominent link to Wiki main page

### DIFF
--- a/wiki/Category_Cookbook.md
+++ b/wiki/Category_Cookbook.md
@@ -1,5 +1,5 @@
 ---
-title: Cookbook entries
+title: Cookbook Entries
 permalink: wiki/Category:Cookbook
 layout: tagpage
 tag: Cookbook

--- a/wiki/Category_Wiki_Documentation.md
+++ b/wiki/Category_Wiki_Documentation.md
@@ -1,5 +1,5 @@
 ---
-title: Category:Wiki Documentation
+title: Wiki Documentation
 permalink: wiki/Category:Wiki_Documentation
 layout: tagpage
 tag: Wiki Documentation

--- a/wiki/Documentation.md
+++ b/wiki/Documentation.md
@@ -29,7 +29,7 @@ below.
 
     [HTML](http://biopython.org/DIST/docs/api)
 
--   Wiki documentation,
+-   [Wiki documentation](Category%3AWiki_Documentation "wikilink")
     -   [Seq](Seq "wikilink") and [SeqRecord](SeqRecord "wikilink")
         objects
     -   [Bio.SeqIO](SeqIO "wikilink") - sequence input/output


### PR DESCRIPTION
The main Wiki page (`Category:Wiki_Documentation`) was only reachable from the main page but not from `Documentation`