### PR TITLE
Clarify the placeholder welcome 

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,10 +3,15 @@ title: Placeholder for Biopython welcome page
 layout: default
 ---
 
-We recently [migrated from MediaWiki to GitHub pages](https://github.com/peterjc/mediawiki_to_git_md),
-see our [GitHub Pages Repository](https://github.com/biopython/biopython.github.io/) for details.
+We recently migrated from MediaWiki to GitHub pages, see our
+[GitHub Pages Repository](https://github.com/biopython/biopython.github.io/)
+and our
+[MediaWiki-to-MarkDown migration project](https://github.com/peterjc/mediawiki_to_git_md)
+for details.
 
 The new site is mostly working, but there are a number of
 [known issues](https://github.com/biopython/biopython.github.io/issues).
 
-Please see the [main page](/wiki/Biopython).
+---------------------------------------
+
+Continue to the [main Wiki page](/wiki/Biopython).


### PR DESCRIPTION
I knew about the migration from MediaWiki to Github, yet when I visited biopython.org, it was really unobvious how to get to the wiki. It seemed to me like the first link on the Placeholder Welcome page should take me there, but that took me to a Github project.  Meanwhile, the actual link was not very descriptive and visually indistinguishable from the notice's text (that is, it looked like it's just another part of the notice). The notice is for the largely technical issue of where the wiki is hosted; most visitors just want to get straight to the wiki (although I recognize the importance of having this notice in the first place in order to inform visitors of potential issues). 

Anyway, I rephrased things a little bit to clarify where each link leads and I added a horizontal rule to separate the notice from the link that most visitors will actually want.