### PR TITLE
Fixing the sidebar footer for different browser sizes

### DIFF
--- a/assets/css/hyde.css
+++ b/assets/css/hyde.css
@@ -92,7 +92,6 @@ hr.head {
   }
   .sidebar-footer {
     position: absolute;
-    bottom: 5px;
     padding: 1rem;
   }
   .container {

--- a/assets/css/hyde.css
+++ b/assets/css/hyde.css
@@ -81,7 +81,8 @@ hr.head {
     bottom: 0;
     width: 16rem;
     text-align: left;
-    padding: 2rem 1rem;
+    padding: 2rem 1rem;     
+    overflow-y: auto;
   }
   .sidebar-nav {
     margin-bottom: 1rem;
@@ -91,7 +92,6 @@ hr.head {
     line-height: 1.75;
   }
   .sidebar-footer {
-    position: absolute;
     padding: 1rem;
   }
   .container {


### PR DESCRIPTION
When the browser is resized, I noticed that the footer interferes with the main menu as observed below - 

![issue](https://cloud.githubusercontent.com/assets/7705170/18233558/ff1b38c2-7307-11e6-8f26-a16906123db6.jpg)

This can be attributed to the bottom margin set in hyde.css - 

`.sidebar-footer {
     position: absolute;
     bottom: 5px;
     padding: 1rem;
   }`

and is fixed on removal without causing issues to other views. 
