### PR TITLE
Fixed bug

### DIFF
--- a/wiki/Phylo_cookbook.md
+++ b/wiki/Phylo_cookbook.md
@@ -325,7 +325,7 @@ def to_adjacency_matrix(tree):
             adjmat[lookup[parent], lookup[child]] = 1
     if not tree.rooted:
         # Branches can go from "child" to "parent" in unrooted trees
-        adjmat += adjmat.transpose
+        adjmat = adjmat + adjmat.transpose()
     return (allclades, numpy.matrix(adjmat))
 ```
 


### PR DESCRIPTION
The += syntax was getting an error regarding incompatible types, and I think you forgot to call the `transpose` function