### PR TITLE
Update mailing list link

### DIFF
--- a/wiki/SourceCode.md
+++ b/wiki/SourceCode.md
@@ -1,5 +1,5 @@
 ---
-title: Source Code
+iitle: Source Code
 permalink: wiki/SourceCode
 layout: page
 redirect_from:
@@ -82,8 +82,8 @@ Biopython developers (including all those who previously had CVS commit
 rights).
 
 This is normally given on a case by case basis, and the best place to
-discuss getting write access is on the [Biopython Development mailing
-list](mailto:biopython-dev@biopython.org).
+discuss getting write access is on the [Biopython mailing
+list](mailto:biopython@biopython.org).
 
 Once you have access, see the instructions on
 [GitUsage](GitUsage "wikilink")

--- a/wiki/SourceCode.md
+++ b/wiki/SourceCode.md
@@ -1,5 +1,5 @@
 ---
-iitle: Source Code
+Title: Source Code
 permalink: wiki/SourceCode
 layout: page
 redirect_from:
@@ -83,7 +83,7 @@ rights).
 
 This is normally given on a case by case basis, and the best place to
 discuss getting write access is on the [Biopython mailing
-list](mailto:biopython@biopython.org).
+lists](https://biopython.org/wiki/Mailing_lists).
 
 Once you have access, see the instructions on
 [GitUsage](GitUsage "wikilink")

--- a/wiki/SourceCode.md
+++ b/wiki/SourceCode.md
@@ -1,5 +1,5 @@
 ---
-Title: Source Code
+title: Source Code
 permalink: wiki/SourceCode
 layout: page
 redirect_from:
@@ -83,7 +83,7 @@ rights).
 
 This is normally given on a case by case basis, and the best place to
 discuss getting write access is on the [Biopython mailing
-lists](https://biopython.org/wiki/Mailing_lists).
+lists](Mailing_lists).
 
 Once you have access, see the instructions on
 [GitUsage](GitUsage "wikilink")


### PR DESCRIPTION
Since we moved to GitHub development discussion in January 2018 we
should point to the main discussion list on the Source Code page.
See <https://biopython.org/wiki/Mailing_lists>