### PR TITLE
Update mailing list link globally

### DIFF
--- a/wiki/Building_a_release.md
+++ b/wiki/Building_a_release.md
@@ -298,7 +298,7 @@ releases):
     ```
 
     - before you announce the release, be sure to send your announcement
-      text to the biopython-dev mailing list for
+      text to the [Biopython mailing list](mailto:biopython@biopython.org) for
       proof-reading/final corrections.
     - add to [main page](Main_Page "wikilink") and [downloads
       page](Download "wikilink") (through the wiki), make sure the links
@@ -309,16 +309,15 @@ releases):
       [twitter](http://twitter.com/Biopython) via the news feed)
     - add the new version to
       [RedMine](https://redmine.open-bio.org/projects/biopython)
-    - send email to biopython@biopython.org and
-      biopython-announce@biopython.org (see [mailing
-      lists](Mailing_lists "wikilink"))
+    - send email to biopython-announce@biopython.org
+      (see [mailing lists](Mailing_lists "wikilink"))
     - forward the email to Linux packagers e.g.
       debian-med@lists.debian.org
 
 21. Conda-Forge should automatically open a pull request to update the
     package once it appears on PyPI. Check for a new pull request on
-    https://github.com/conda-forge/biopython-feedstock which once merged
-    will upload the new release to https://anaconda.org/conda-forge/biopython
+    [github.com/conda-forge/biopython-feedstock](https://github.com/conda-forge/biopython-feedstock)
+    which once merged will upload the new release to [anaconda.org/conda-forge/biopython](https://anaconda.org/conda-forge/biopython)
 
 22. Bump version numbers again
 

--- a/wiki/Continuous_integration.md
+++ b/wiki/Continuous_integration.md
@@ -31,8 +31,8 @@ Currently you have 3 options
 1.  Visit our [buildbot web site](http://testing.open-bio.org/biopython)
 2.  Subscribe to the integration [RSS
     feed](http://testing.open-bio.org/biopython/rss)
-3.  Subscribe to the biopython-dev mailing list where important errors
-    are automatically forward (under construction)
+3.  Subscribe to the [Biopython mailing list](mailto:biopython@biopython.org)
+    where important errors are automatically forward (under construction)
 
 Volunteer integration testing
 =============================

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -97,11 +97,11 @@ Before you submit it, please check that:
     new code.
 
 If all these terms seem acceptable, please send a description of your
-code to biopython-dev@biopython.org (see [Mailing
-lists](Mailing_lists "wikilink")). Be sure to subscribe to biopython-dev
+code to [biopython@biopython.org](mailto:biopython@biopython.org) (see [Mailing
+lists](Mailing_lists "wikilink")). Be sure to subscribe to biopython mailing list
 before sending a message, otherwise your message will be discarded by
 the mail server (this was done to avoid spam on the mailing list). Don't
-send the code directly to the biopython-dev mailing list. Instead,
+send the code directly to the biopython mailing list. Instead,
 please use [our GitHub page](https://github.com/biopython/biopython/) by
 creating an issue and either attaching the file(s) or linking to your
 GitHub branch.

--- a/wiki/Deprecation_policy.md
+++ b/wiki/Deprecation_policy.md
@@ -17,10 +17,9 @@ changes, named
 This is the current policy for deprecating and removing code from
 Biopython:
 
--   First, ask on the Biopython and biopython-dev [mailing
-    lists](Mailing_lists "wikilink") whether a given piece of code has
-    any users. Please keep in mind that not all users are following the
-    biopython-dev mailing list.
+-   First, ask on the [Biopython mailing lists](Mailing_lists "wikilink")
+    whether a given piece of code has any users. Please keep in mind that
+    not all users are following the biopython mailing list.
 -   Consider declaring the module as "obsolete" for a release
     *before* deprecation. No code changes, just:
     -   Note this in the DEPRECATED file,

--- a/wiki/Deprecation_policy.md
+++ b/wiki/Deprecation_policy.md
@@ -17,7 +17,7 @@ changes, named
 This is the current policy for deprecating and removing code from
 Biopython:
 
--   First, ask on the [Biopython mailing lists](Mailing_lists "wikilink")
+-   First, ask on the [Biopython mailing list](Mailing_lists "wikilink")
     whether a given piece of code has any users. Please keep in mind that
     not all users are following the biopython mailing list.
 -   Consider declaring the module as "obsolete" for a release

--- a/wiki/MotifDev.md
+++ b/wiki/MotifDev.md
@@ -45,5 +45,5 @@ based motif searching:
 -   Supporting HMM-based motifs (with dependencies between positions)
 -   particular tools like HMMer
 
-If you want to contribute, please contact bartek@rezolwenta.eu.org or
-biopython-dev@biopython.org
+If you want to contribute, please contact [bartek@rezolwenta.eu.org](mailto:bartek@rezolwenta.eu.org) or
+[biopython@biopython.org](mailto:biopython@biopython.org).

--- a/wiki/SourceCode.md
+++ b/wiki/SourceCode.md
@@ -1,5 +1,5 @@
 ---
-iitle: Source Code
+Title: Source Code
 permalink: wiki/SourceCode
 layout: page
 redirect_from:

--- a/wiki/SourceCode.md
+++ b/wiki/SourceCode.md
@@ -1,5 +1,5 @@
 ---
-Title: Source Code
+title: Source Code
 permalink: wiki/SourceCode
 layout: page
 redirect_from:

--- a/wiki/SourceCode.md
+++ b/wiki/SourceCode.md
@@ -1,5 +1,5 @@
 ---
-title: Source Code
+iitle: Source Code
 permalink: wiki/SourceCode
 layout: page
 redirect_from:

--- a/wiki/SourceCode.md
+++ b/wiki/SourceCode.md
@@ -83,7 +83,7 @@ rights).
 
 This is normally given on a case by case basis, and the best place to
 discuss getting write access is on the [Biopython mailing
-lists](Mailing_lists).
+list](Mailing_lists).
 
 Once you have access, see the instructions on
 [GitUsage](GitUsage "wikilink")

--- a/wiki/SourceCode.md
+++ b/wiki/SourceCode.md
@@ -38,7 +38,7 @@ github](http://github.com/biopython/biopython).
 ### Track Changes
 
 You can track code development by [RSS feed](https://github.com/biopython/biopython/commits/master.atom)
-or the [Biopython Development mailing list](mailto:biopython-dev@biopython.org).
+or the [Biopython mailing list](mailto:biopython@biopython.org).
 See also our other [mailing lists](Mailing_lists "wikilink").
 
 ### Downloading the Latest Source

--- a/wiki/The_Biopython_Structural_Bioinformatics_FAQ.md
+++ b/wiki/The_Biopython_Structural_Bioinformatics_FAQ.md
@@ -1010,5 +1010,5 @@ Can I contribute?
 
 Yes, yes, yes! Just send an e-mail to [Thomas
 Hamelryck](mailto:thamelry@binf.ku.dk) or to [the Biopython
-developers](mailto:biopython-dev@biopython.org) if you have something
+developers](mailto:biopython@biopython.org) if you have something
 useful to contribute! Eternal fame awaits!


### PR DESCRIPTION
Since biopython-dev@biopython.org mailing list is closed since January 2018. We should change to biopython@biopython.org mailing list in the whole site.