### PR TITLE
Improve compatibility with new version of mysql

### DIFF
--- a/wiki/BioSQL.md
+++ b/wiki/BioSQL.md
@@ -53,6 +53,8 @@ Ubuntu Linux machine try this:
 sudo apt-get install mysql-common mysql-server python-mysqldb
 ```
 
+A password is required for logon. Please refer to [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/linux-installation-debian.html).
+
 It will also be important to have perl (to run some of the setup
 scripts). Again, on a Debian or Ubuntu Linux machine try this:
 
@@ -84,24 +86,7 @@ Creating the empty database
 
 ### MySQL
 
-Some systems like Ubuntu, new version of mysql is using by default the [UNIX auth_socket plugin](https://dev.mysql.com/doc/mysql-security-excerpt/5.5/en/socket-pluggable-authentication.html) if the password is left empty while installing. To proceed, a password is recommended.
-
-```bash
-sudo mysql -u root -p
-```
-
-```bash
-ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'your-password';
-```
-
-Once finished.
-
-```bash
-sudo service mysql stop
-sudo service mysql start
-```
-
-Therefore, the following command line should create a new database on your own
+The following command line should create a new database on your own
 computer called *bioseqdb*, belonging to the *root* user account:
 
 ``` bash

--- a/wiki/BioSQL.md
+++ b/wiki/BioSQL.md
@@ -84,11 +84,28 @@ Creating the empty database
 
 ### MySQL
 
-The following command line should create a new database on your own
+Some systems like Ubuntu, new version of mysql is using by default the [UNIX auth_socket plugin](https://dev.mysql.com/doc/mysql-security-excerpt/5.5/en/socket-pluggable-authentication.html) if the password is left empty while installing. To proceed, a password is recommended.
+
+```bash
+sudo mysql -u root -p
+```
+
+```bash
+ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'your-password';
+```
+
+Once finished.
+
+```bash
+sudo service mysql stop
+sudo service mysql start
+```
+
+Therefore, the following command line should create a new database on your own
 computer called *bioseqdb*, belonging to the *root* user account:
 
 ``` bash
-mysqladmin -u root create bioseqdb
+mysqladmin -u root -p create biosqldb
 ```
 
 We can then tell MySQL to load the BioSQL scheme we downloaded above.
@@ -96,14 +113,14 @@ Change to the scripts subdirectory from the unzipped BioSQL download,
 then:
 
 ``` bash
-mysql -u root bioseqdb < biosqldb-mysql.sql
+mysql -u root -p bioseqdb < biosqldb-mysql.sql
 ```
 
 You can have a quick play using the mysql command line tool, for
 example:
 
 ``` bash
-mysql --user=root bioseqdb -e "show tables"
+mysql --user=root -p bioseqdb -e "show tables"
 ```
 
 giving:
@@ -146,7 +163,7 @@ giving:
 Or, to look inside a table:
 
 ``` bash
-mysql --user=root bioseqdb -e "select * from bioentry;"
+mysql --user=root -p bioseqdb -e "select * from bioentry;"
 ```
 
 This should return no rows as the table is empty.
@@ -262,7 +279,7 @@ and a little lower down,
 ``` python
 DBHOST = 'localhost'
 DBUSER = 'root'
-DBPASSWD = ''
+DBPASSWD = 'your-password'
 TESTDB = 'biosql_test'
 ```
 
@@ -290,7 +307,7 @@ example, lets create a one for some orchid sequences:
 ``` python
 from BioSQL import BioSeqDatabase
 server = BioSeqDatabase.open_database(driver="MySQLdb", user="root",
-                     passwd = "", host = "localhost", db="bioseqdb")
+                     passwd = "your-password", host = "localhost", db="bioseqdb")
 db = server.new_database("orchids", description="Just for testing")
 server.commit() #On Biopython 1.49 or older, server.adaptor.commit()
 ```
@@ -312,7 +329,7 @@ orchid namespace. You can check this at the command line:
 MySQL:
 
 ``` bash
-mysql --user=root bioseqdb -e "select * from biodatabase;"
+mysql --user=root -p bioseqdb -e "select * from biodatabase;"
 ```
 
 PostgreSQL:
@@ -375,7 +392,7 @@ from Bio import Entrez
 from Bio import SeqIO
 from BioSQL import BioSeqDatabase
 server = BioSeqDatabase.open_database(driver="MySQLdb", user="root",
-                     passwd = "", host = "localhost", db="bioseqdb")
+                     passwd = "your-password", host = "localhost", db="bioseqdb")
 db = server["orchids"]
 handle = Entrez.efetch(db="nuccore", id="6273291,6273290,6273289", rettype="gb", retmode="text")
 count = db.load(SeqIO.parse(handle, "genbank"))
@@ -400,7 +417,7 @@ mysql --user=root bioseqdb -e "select * from biosequence;"
 The should also be nine new features:
 
 ``` bash
-mysql --user=root bioseqdb -e "select * from seqfeature;"
+mysql --user=root -p bioseqdb -e "select * from seqfeature;"
 ```
 
 Next, we'll try and load these three records back from the database.
@@ -414,7 +431,7 @@ into an *orchids* database (namespace):
 ``` python
 from BioSQL import BioSeqDatabase
 server = BioSeqDatabase.open_database(driver="MySQLdb", user="root",
-                     passwd = "", host = "localhost", db="bioseqdb")
+                     passwd = "your-password", host = "localhost", db="bioseqdb")
 db = server["orchids"]
 for identifier in ['6273291', '6273290', '6273289'] :
     seq_record = db.lookup(gi=identifier)
@@ -449,7 +466,7 @@ e.g.
 ``` python
 from BioSQL import BioSeqDatabase
 server = BioSeqDatabase.open_database(driver="MySQLdb", user="root",
-                     passwd = "", host = "localhost", db="bioseqdb")
+                     passwd = "your-password", host = "localhost", db="bioseqdb")
 db = server["orchids"]
 print "This database contains %i records" % len(db)
 for key, record in db.iteritems():
@@ -468,7 +485,7 @@ the records in it):
 ``` python
 from BioSQL import BioSeqDatabase
 server = BioSeqDatabase.open_database(driver="MySQLdb", user="root",
-                     passwd = "", host = "localhost", db="bioseqdb")
+                     passwd = "your-password", host = "localhost", db="bioseqdb")
 server.remove_database("orchids")
 server.commit() #On Biopython 1.49 or older, server.adaptor.commit()
 ```
@@ -480,7 +497,7 @@ There should now be one less row in the *biodatabase* table, check this
 at the command line:
 
 ``` bash
-mysql --user=root bioseqdb -e "select * from biodatabase;"
+mysql --user=root -p bioseqdb -e "select * from biodatabase;"
 ```
 
 You can also check that the three orchid sequences have gone from the
@@ -503,7 +520,7 @@ If you are getting timeout errors, check to see if your SQL server has
 any orphaned threads.
 
 ``` bash
-mysql --user=root bioseqdb -e "SHOW INNODB STATUS\G" | grep "thread id"
+mysql --user=root -p bioseqdb -e "SHOW INNODB STATUS\G" | grep "thread id"
 ```
 
 And if there are, assuming you are the only person using this database,
@@ -511,7 +528,7 @@ you might try killing them off using the thread id given by the above
 command:
 
 ``` bash
-mysql --user=root bioseqdb -e "KILL 123;"
+mysql --user=root -p bioseqdb -e "KILL 123;"
 ```
 
 Use at your own risk!


### PR DESCRIPTION
When running `mysqladmin -u root create biosqldb` with MySQL as 5.7.27-0 on Ubuntu 18.04, I got a warning saying  `mysqladmin: connect to server at 'localhost' failed
error: 'Access denied for user 'root'@'localhost''`. 

This problem seems to be that new mysql takes use of the `auth_socket` plugin if the password is left empty while installing. Answers from [stackoverflow](https://stackoverflow.com/questions/39281594/error-1698-28000-access-denied-for-user-rootlocalhost) suggest a password is required. Therefore, I changed the codes here for compatibility with the new version of mysql. 

**These codes were only tested on Ubuntu 18.04.**