### PR TITLE
Replace 'site.baseurl' with relative_url filter

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -22,11 +22,11 @@
   <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans%3A400,400italic,700%7CAbril+Fatface">
 
   <!-- Icons -->
-  <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="{{ site.baseurl }}favicon-16x16.png">
-  <link rel="manifest" href="{{ site.baseurl }}site.webmanifest">
-  <link rel="mask-icon" href="{{ site.baseurl }}safari-pinned-tab.svg" color="#5bbad5">
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ "/" | relative_url }}apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ "/" | relative_url }}favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="{{ "/" | relative_url }}favicon-16x16.png">
+  <link rel="manifest" href="{{ "/" | relative_url }}site.webmanifest">
+  <link rel="mask-icon" href="{{ "/" | relative_url }}safari-pinned-tab.svg" color="#5bbad5">
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="theme-color" content="#000000">
 


### PR DESCRIPTION
`site.baseurl` is not directing to the 'root' URL (any longer). Thus replace with `relative_url`.

This will close #179