### PR TITLE
Deprecation of "rU"

### DIFF
--- a/wiki/SeqIO.md
+++ b/wiki/SeqIO.md
@@ -133,20 +133,9 @@ with open("example.fasta") as handle:
 ```
 
 In the above example, we opened the file using the built-in python
-function `open`. If you are using Python version that is less than 3.4,
-you can add `'rU'` to the open function as
-
-``` python
-with open("example.fasta","rU") as handle:
-```
-
-The argument `'rU'` means open for **r**eading using
-**u**niversal readline mode - this means you don't have to worry if the
-file uses Unix, Mac or DOS/Windows style newline characters. If you use
-Python 3.4+, you do not need to worry about it. 
-
-The `with`- statement makes sure that the file is properly closed after reading it.
-That should all happen automatically if you just use the filename instead.
+function `open`. The `with`- statement makes sure that the file is properly 
+closed after reading it. That should all happen automatically if you 
+just use the filename instead.
 
 Note that you *must* specify the file format explicitly, unlike
 [BioPerl's SeqIO](http://bioperl.org/howtos/SeqIO_HOWTO) which can try to guess

--- a/wiki/SeqIO.md
+++ b/wiki/SeqIO.md
@@ -127,16 +127,25 @@ or using a handle:
 ``` python
 from Bio import SeqIO
 
-with open("example.fasta", "rU") as handle:
+with open("example.fasta") as handle:
     for record in SeqIO.parse(handle, "fasta"):
         print(record.id)
 ```
 
 In the above example, we opened the file using the built-in python
-function `open`. The argument `'rU'` means open for **r**eading using
+function `open`. If you are using Python version that is less than 3.4,
+you can add `'rU'` to the open function as
+
+``` python
+with open("example.fasta","rU") as handle:
+```
+
+The argument `'rU'` means open for **r**eading using
 **u**niversal readline mode - this means you don't have to worry if the
-file uses Unix, Mac or DOS/Windows style newline characters. The `with`-
-statement makes sure that the file is properly closed after reading it.
+file uses Unix, Mac or DOS/Windows style newline characters. If you use
+Python 3.4+, you do not need to worry about it. 
+
+The `with`- statement makes sure that the file is properly closed after reading it.
 That should all happen automatically if you just use the filename instead.
 
 Note that you *must* specify the file format explicitly, unlike
@@ -154,7 +163,7 @@ which contains seven sequences, the only difference is you specify
 ``` python
 from Bio import SeqIO
 
-with open("opuntia.aln", "rU") as handle:
+with open("opuntia.aln") as handle:
     for record in SeqIO.parse(handle, "clustal"):
         print(record.id)
 ```
@@ -278,7 +287,7 @@ function:
 ``` python
 from Bio import SeqIO
 
-with open("cor6_6.gb", "rU") as input_handle:
+with open("cor6_6.gb") as input_handle:
     for record in SeqIO.parse(input_handle, "genbank"):
         print(record)
 ```
@@ -290,7 +299,7 @@ function, to turn this GenBank file into a Fasta file:
 ``` python
 from Bio import SeqIO
 
-with open("cor6_6.gb", "rU") as input_handle, open(
+with open("cor6_6.gb") as input_handle, open(
     "cor6_6.fasta", "w"
 ) as output_handle:
     sequences = SeqIO.parse(input_handle, "genbank")

--- a/wiki/SeqIO.md
+++ b/wiki/SeqIO.md
@@ -133,8 +133,8 @@ with open("example.fasta") as handle:
 ```
 
 In the above example, we opened the file using the built-in python
-function `open`. The `with`- statement makes sure that the file is properly 
-closed after reading it. That should all happen automatically if you 
+function `open`. The `with`- statement makes sure that the file is properly
+closed after reading it. That should all happen automatically if you
 just use the filename instead.
 
 Note that you *must* specify the file format explicitly, unlike


### PR DESCRIPTION
"rU" was deprecated in Python 3.4, so it is not needed. For Python 3.4+, "rU" will give deprecation error.