### PR TITLE
Add correct import statement to FAQ

### DIFF
--- a/wiki/The_Biopython_Structural_Bioinformatics_FAQ.md
+++ b/wiki/The_Biopython_Structural_Bioinformatics_FAQ.md
@@ -168,6 +168,8 @@ all atoms), the tag is mapped to a list of values. The dictionary is
 created from the mmCIF file as follows:
 
 ``` python
+from Bio.PDB.MMCIF2Dict import MMCIF2Dict
+
 mmcif_dict = MMCIF2Dict("1FAT.cif")
 ```
 


### PR DESCRIPTION
I was having an issue following along with the code on this page. When I only ran the code as it was described, I would get this error:

```
>>> MMCIF2Dict("5SWE.Cif")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'module' object is not callable
```

Earlier in the wiki page, you're told to run `from Bio.PDB import *`, which imports the _**module**_ of `MMCIF2Dict`, but not the class. So I updated the doc since I I think this is actually the second time I've landed on this page and experienced this problem.