### PR TITLE
Fix mixed content by updating Google Fonts link to HTTPS

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href={{ "/assets/css/poole.css" | relative_url }}>
   <link rel="stylesheet" href={{ "/assets/css/syntax.css" | relative_url }}>
   <link rel="stylesheet" href={{ "/assets/css/hyde.css"> | relative_url }}>
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans%3A400,400italic,700%7CAbril+Fatface">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->
   <link rel="apple-touch-icon" sizes="180x180" href={{ "/apple-touch-icon.png" | relative_url }}>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href={{ "/assets/css/poole.css" | relative_url }}>
   <link rel="stylesheet" href={{ "/assets/css/syntax.css" | relative_url }}>
   <link rel="stylesheet" href={{ "/assets/css/hyde.css"> | relative_url }}>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans%3A400,400italic,700%7CAbril+Fatface">
 
   <!-- Icons -->
   <link rel="apple-touch-icon" sizes="180x180" href={{ "/apple-touch-icon.png" | relative_url }}>


### PR DESCRIPTION
The browser displayed the following warning:
```text
Mixed Content: The page at 'https://biopython.org/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=PT+Sans%3A400,400italic,700%7CAbril+Fatface'. This request has been blocked; the content must be served over HTTPS.
```
The Google Fonts link has been updated to use HTTPS to resolve this issue.

Verified locally:
- Font request to `https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface` returns 200 OK
- Styles load as expected (confirmed in Styles panel)
